### PR TITLE
Update Excludes List regular expression standard

### DIFF
--- a/docs/user_guide/runtime_ima.rst
+++ b/docs/user_guide/runtime_ima.rst
@@ -97,10 +97,11 @@ Excludes List
 ~~~~~~~~~~~~~
 
 An excludes list can be utilised to exclude any file or path. The excludes list
-supports standard regular expressions, for example the `tmp` directory can be
-ignored::
+uses the Python regular expression standard, where the syntax is similar to
+those found in Perl. Note that this syntax is different from POSIX basic
+regular expressions. For example the `tmp` directory can be ignored using::
 
-  /tmp/*
+  /tmp/.*
 
 
 Remotely Provision Agents


### PR DESCRIPTION
This updates the regular expression wording in the `Excludes List` section to avoid confusion. This was identified as a result of fixing https://github.com/keylime/keylime/pull/303.