### PR TITLE
Update User Guide page to link to secure payloads doc

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -8,5 +8,5 @@ User Guide
 
    user_guide/user_selected_pcr_monitoring.rst
    user_guide/runtime_ima.rst
-   user_guide/encrypted_payload.rst
+   user_guide/secure_payload.rst
    user_guide/revocation.rst


### PR DESCRIPTION
Forget to update the [User Guide](https://keylime-docs.readthedocs.io/en/latest/user_guide.html) page so that it will link to the recently published [Secure Payloads documentation](https://keylime-docs.readthedocs.io/en/latest/user_guide/secure_payloads.html). This tiny commit fixes this.

Signed-off-by: axelsimon <github@axelsimon.net>