### PR TITLE
fix: Use correct driver name: postgresql

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -272,7 +272,7 @@ PostgreSQL
 For PostgreSQL you will need to install the database first and set up a user
 account::
 
-    database_drivername = postgres
+    database_drivername = postgresql
     database_username = keylime
     database_password = allyourbase
     database_host = localhost


### PR DESCRIPTION
Correct driver name is postgresql not postgres.

Error log:
```
Dec 21 11:14:50 keylime-v keylime_verifier[10014]: Using config file /etc/keylime.conf
Dec 21 11:14:50 keylime-v keylime_verifier[10014]: 2021-12-21 11:14:50.163 - keylime.keylime_db - INFO - database_url is not set, using multi-parameter database configuration options
Dec 21 11:14:50 keylime-v keylime_verifier[10014]: 2021-12-21 11:14:50.170 - keylime.cloudverifier - ERROR - Error creating SQL engine or session: Can't load plugin: sqlalchemy.dialects:postgres
Dec 21 11:14:50 keylime-v systemd[1]: keylime_verifier.service: Main process exited, code=exited, status=1/FAILURE
Dec 21 11:14:50 keylime-v systemd[1]: keylime_verifier.service: Failed with result 'exit-code'.
```

See https://stackoverflow.com/questions/62688256/sqlalchemy-exc-nosuchmoduleerror-cant-load-plugin-sqlalchemy-dialectspostgre

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>